### PR TITLE
Prevent errors if `wikibaseManifestEquivEntities` doesn't exist

### DIFF
--- a/src/backend/mocks/default_handlers.js
+++ b/src/backend/mocks/default_handlers.js
@@ -35,7 +35,8 @@ const makeNewWiki = ({ domain, sitename }) => {
       id: 101,
       wiki_id: lastWikiId,
       version: 'mw1.33-wbs1'
-    }
+    },
+    public_settings: []
   }
 
   myWikis.push(newWiki)

--- a/src/store/wikis.js
+++ b/src/store/wikis.js
@@ -33,9 +33,8 @@ const mutations = {
     state.status = 'error'
   },
   set_current_wiki_settings (state, details) {
-    const entityMapping = JSON.parse(
-      details.public_settings.find(setting => setting.name === 'wikibaseManifestEquivEntities').value
-    )
+    const entityMappingSetting = details.public_settings.find(setting => setting.name === 'wikibaseManifestEquivEntities')
+    const entityMapping = entityMappingSetting ? JSON.parse(entityMappingSetting.value) : { properties: {}, items: {} }
     state.currentWikiSettings = { entityMapping }
   },
   set_item_mapping (state, mapping) {


### PR DESCRIPTION
This prevents an error in the `set_current_wiki_settings` mutation in case the `wikibaseManifestEquivEntities` setting isn't set.

It also adds `public_settings: []` to the mock wiki data. You'll need to clear local storage for it to take effect.