### PR TITLE
Use the same port for host and container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,6 @@ services:
     working_dir: /home/node/app
     volumes:
     - ./:/home/node/app
-    command: npm run serve
+    command: npm run serve -- --port 8081
     ports:
-      - 8081:8080
+      - 8081:8081


### PR DESCRIPTION
This makes the URL that the dev server prints to the console actually
clickable and useful.

Previously running `docker-compose up ui` printed 
> ui_1  |   App running at:
> ui_1  |   - Local:   http://localhost:8080/ 

to the console when it actually exposed 8081 to the host. Now it shows 8081 :tada: 