### PR TITLE
Prettify WhatCanYouDo cards

### DIFF
--- a/src/components/Pages/Home/LoggedOutFeatures/WhatCanYouDo.vue
+++ b/src/components/Pages/Home/LoggedOutFeatures/WhatCanYouDo.vue
@@ -9,9 +9,9 @@
     <v-row>
       <v-col>
         <!-- START blocks side by side -->
-          <v-row align="start" justify="space-between">
+          <v-row align="stretch" justify="space-between">
             <v-col cols="3">
-              <v-card>
+              <v-card class="what-can-you-do__card">
                 <v-card-title><h3>Create a Wikibase</h3></v-card-title>
                 <v-card-text>
                 Get set up in under a minute, with no technical knowledge, get automatic upgrades and much more.
@@ -19,19 +19,19 @@
               </v-card>
             </v-col>
             <v-col cols="3">
-              <v-card>
+              <v-card class="what-can-you-do__card">
                 <v-card-title><h3>Build a community</h3></v-card-title>
                 <v-card-text>Allow people to find your data, in the standard Wikibase format, and help you curate it.</v-card-text>
               </v-card>
             </v-col>
             <v-col cols="3">
-              <v-card>
+              <v-card class="what-can-you-do__card">
                 <v-card-title><h3>Link to other data</h3></v-card-title>
                 <v-card-text>Link to other open data sets and become part of the <a target="_blank" rel="noopener noreferrer" href="https://lod-cloud.net/">Linked Open Data Cloud</a>.</v-card-text>
               </v-card>
             </v-col>
             <v-col cols="3">
-              <v-card>
+              <v-card class="what-can-you-do__card">
                 <v-card-title><h3>Query everything</h3></v-card-title>
                 <v-card-text>Data and input managed by <a target="_blank" rel="noopener noreferrer" href="https://www.mediawiki.org/wiki/MediaWiki" >MediaWiki</a>, Triples and querying handled in <a target="_blank" rel="noopener noreferrer" href="https://www.wikidata.org/wiki/Wikidata:SPARQL_tutorial" >SPARQL</a> via Blazegraph.</v-card-text>
               </v-card>
@@ -61,8 +61,11 @@ export default {
 </script>
 
 <style scoped>
-
 h1 {
   margin-bottom: 16px;
+}
+
+.what-can-you-do__card {
+  height: 100%;
 }
 </style>

--- a/src/components/Pages/Home/LoggedOutFeatures/WhatCanYouDo.vue
+++ b/src/components/Pages/Home/LoggedOutFeatures/WhatCanYouDo.vue
@@ -68,4 +68,8 @@ h1 {
 .what-can-you-do__card {
   height: 100%;
 }
+
+.what-can-you-do__card h3 {
+  word-break: normal;
+}
 </style>


### PR DESCRIPTION
Before:
<img width="976" alt="Screenshot 2021-03-27 at 13 16 05" src="https://user-images.githubusercontent.com/453024/112720449-a79f3b80-8efe-11eb-9fe2-855a4de3679a.png">

After:
<img width="983" alt="Screenshot 2021-03-27 at 13 15 54" src="https://user-images.githubusercontent.com/453024/112720456-b38afd80-8efe-11eb-8e40-9524a462f717.png">

Apparently there's a chance that the `word-break` change [might break something in IE](https://github.com/vuetifyjs/vuetify/issues/9130#issuecomment-546007275)? I can't easily test it and don't know how important that is :P