### PR TITLE
fix(ci): push parameter default is false and prevents pushing

### DIFF
--- a/.github/workflows/docker.build.yml
+++ b/.github/workflows/docker.build.yml
@@ -51,6 +51,7 @@ jobs:
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          push: true
       -
         name: Check out `wmde/wbaas-deploy` repository in staging child directory
         uses: actions/checkout@v3


### PR DESCRIPTION
Fixup for #626 which inadvertently stopped pushing the built images to the registry.