### PR TITLE
fix(ci): commit message needs to be quoted before echoing

### DIFF
--- a/.github/workflows/docker.build.yml
+++ b/.github/workflows/docker.build.yml
@@ -77,7 +77,7 @@ jobs:
         name: Truncate commit message
         id: truncate-commit-message
         run: |
-          MSG=$(echo ${{ github.event.head_commit.message }} | head -n 1)
+          MSG=$(echo "${{ github.event.head_commit.message }}" | head -n 1)
           echo "msg=$MSG" >> $GITHUB_OUTPUT
       -
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
In #628 I forgot to shell quote the commit message before passing it to `echo`, so the Action currently fails with:

```
Run MSG=$(echo fix(ci): multi line commit messages break PR body (#628) | head -n 1)
  MSG=$(echo fix(ci): multi line commit messages break PR body (#6[2](https://github.com/wbstack/ui/actions/runs/4182378720/jobs/7245394759#step:12:2)8) | head -n 1)
  echo "msg=$MSG" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/97e2[3](https://github.com/wbstack/ui/actions/runs/4182378720/jobs/7245394759#step:12:3)889-8ec9-[4](https://github.com/wbstack/ui/actions/runs/4182378720/jobs/7245394759#step:12:4)[5](https://github.com/wbstack/ui/actions/runs/4182378720/jobs/7245394759#step:12:6)35-b0bd-6aa7ca4edc5f.sh: line 1: unexpected EOF while looking for matching `)'
```