### PR TITLE
Fix Login error feedback handling

### DIFF
--- a/src/components/Cards/Login.vue
+++ b/src/components/Cards/Login.vue
@@ -78,10 +78,7 @@ export default {
           console.log(err.response)
 
           // If the api gave use details of the error, then use them
-          if (err.response !== undefined &&
-                err.response.data !== undefined &&
-                err.response.data.errors !== undefined
-          ) {
+          if (err.response && err.response.data && err.response.data.errors) {
             if (err.response.data.errors.email) {
               this.error.email = err.response.data.errors.email[0]
             }

--- a/src/components/Cards/Login.vue
+++ b/src/components/Cards/Login.vue
@@ -78,7 +78,10 @@ export default {
           console.log(err.response)
 
           // If the api gave use details of the error, then use them
-          if (err.response.data.errors) {
+          if (err.response !== undefined &&
+                err.response.data !== undefined &&
+                err.response.data.errors !== undefined
+          ) {
             if (err.response.data.errors.email) {
               this.error.email = err.response.data.errors.email[0]
             }


### PR DESCRIPTION
This aims to fix the issue that the Login form does "freeze" in a gray state if the login fails and the API does not provide additional details.


