### PR TITLE
fix(ci): netlify preview does not always delegate routing to SPA

### DIFF
--- a/.github/workflows/netlify-preview.yml
+++ b/.github/workflows/netlify-preview.yml
@@ -21,6 +21,10 @@ jobs:
     - run: npm ci
     - run: npm run build
 
+    - name: Enable SPA routing on Netlify
+      run: |
+        echo "/*    /index.html   200" > ./dist/_redirects
+
     - name: Deploy branch preview to Netlify
       id: netlify_deploy
       run: echo "::set-output name=url::$(npx -p netlify-cli
@@ -50,6 +54,10 @@ jobs:
         node-version: 14.x
     - run: npm ci
     - run: npm run build
+
+    - name: Enable SPA routing on Netlify
+      run: |
+        echo "/*    /index.html   200" > ./dist/_redirects
 
     - name: Deploy branch preview to Netlify
       id: netlify_deploy


### PR DESCRIPTION
In a Netlify preview it's currently not possible to "browser reload" a non-index page, e.g. `/login` (a 404 page is shown instead). This PR makes Netlify delegate routing of requests that do not match a file to Vue's SPA router, allowing users to reload any page while testing.