### PR TITLE
fix(workflow): quoting in truncate-commit-message

### DIFF
--- a/.github/workflows/docker.build.yml
+++ b/.github/workflows/docker.build.yml
@@ -77,7 +77,7 @@ jobs:
         name: Truncate commit message
         id: truncate-commit-message
         run: |
-          MSG=$(echo "${{ github.event.head_commit.message }}" | head -n 1)
+          MSG=$(echo '${{ github.event.head_commit.message }}' | head -n 1)
           echo "msg=$MSG" >> $GITHUB_OUTPUT
       -
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
Double quotes in commit messages broke the `truncate-commit-message` workflow step of `docker-build` - this hopefully fixes it

example: https://github.com/wbstack/ui/actions/runs/5853401197/job/15867755875#step:12:21