### PR TITLE
fix(discovery): alphabetical sorting needs to be inversed

### DIFF
--- a/src/components/Pages/Discovery/Discovery.vue
+++ b/src/components/Pages/Discovery/Discovery.vue
@@ -56,14 +56,14 @@ const SortOptions = {
   alphaAsc: {
     text: 'Alphabetically ↑',
     value: {
-      direction: 'asc',
+      direction: 'desc',
       sort: 'sitename'
     }
   },
   alphaDesc: {
     text: 'Alphabetically ↓',
     value: {
-      direction: 'desc',
+      direction: 'asc',
       sort: 'sitename'
     }
   },


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T344436

Sorting names for alphanumerical values are not really intuitive, so this got mixed up.