### PR TITLE
Remove alpha phase wording

### DIFF
--- a/src/components/Pages/ManageWiki/Cards/Details.vue
+++ b/src/components/Pages/ManageWiki/Cards/Details.vue
@@ -7,7 +7,7 @@
         <template v-slot:activator="{ on }">
           <v-icon v-on="on">mdi-information-outline</v-icon>
         </template>
-        <span>During Alpha if you would like to change these details please contact us.</span>
+        <span>If you would like to change these details please contact us.</span>
       </v-tooltip>
     </v-card-title>
     <v-card-text>


### PR DESCRIPTION
Theres a tooltip containing confusing wording mentioning alpha phase, we are in beta though, this drops it.
