### PR TITLE
Use node 15 only

### DIFF
--- a/.github/workflows/netlify-preview.yml
+++ b/.github/workflows/netlify-preview.yml
@@ -14,10 +14,10 @@ jobs:
       with:
         env-file: .env.development.mock
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 15.x
       uses: actions/setup-node@v3.7.0
       with:
-        node-version: 14.x
+        node-version: 15.x
     - run: npm ci
     - run: npm run build
 
@@ -48,10 +48,10 @@ jobs:
       with:
         env-file: .env.development.prod
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 15.x
       uses: actions/setup-node@v3.7.0
       with:
-        node-version: 14.x
+        node-version: 15.x
     - run: npm ci
     - run: npm run build
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 15]
+        node-version: [15]
 
     steps:
     - uses: actions/checkout@v3.5.3

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   ],
   "_id": "wikwiki-ui@1.0.0",
   "engines": {
-    "node": ">= 11.0.0",
+    "node": ">= 15.0.0",
     "npm": ">= 6.4.1"
   },
   "gitHooks": {


### PR DESCRIPTION
This will speed up CI
In the case where a run does fail, there is less to retry etc
Dockerfile currently uses 15, so just use that...
