### PR TITLE
nginx: add Cache-Control header

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -21,6 +21,8 @@ server {
   location / {
       root /usr/share/nginx/html;
       try_files $uri /index.html;
+
+      add_header 'Cache-Control' 'max-age: 31536000, immutable' always;
   }
 
   location = /index.html {

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -22,9 +22,11 @@ server {
       root /usr/share/nginx/html;
       try_files $uri /index.html;
 
-      add_header 'Cache-Control' 'max-age: 31536000, immutable' always;
+      # cache everything for 1 week
+      add_header 'Cache-Control' 'max-age: 604800, immutable' always; 
   }
 
+  # do not cache index.html - https://phabricator.wikimedia.org/T331423
   location = /index.html {
       add_header 'Cache-Control' 'no-cache' always;
   }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -26,8 +26,8 @@ server {
       add_header 'Cache-Control' 'max-age: 31536000, immutable' always; 
   }
 
-  # do not cache index.html - https://phabricator.wikimedia.org/T331423
-  location = /index.html {
+  # do not cache index.html or config.js - https://phabricator.wikimedia.org/T331423
+  location ~ /(index.html|config.js) {
       add_header 'Cache-Control' 'no-cache' always;
   }
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -21,7 +21,9 @@ server {
   location / {
       root /usr/share/nginx/html;
       try_files $uri /index.html;
+  }
 
+  location = /index.html {
       add_header 'Cache-Control' 'no-cache' always;
   }
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -21,6 +21,8 @@ server {
   location / {
       root /usr/share/nginx/html;
       try_files $uri /index.html;
+
+      add_header 'Cache-Control' 'no-cache' always;
   }
 
   # deny access to .htaccess files, if Apache's document root concurs with nginx's one

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -22,8 +22,8 @@ server {
       root /usr/share/nginx/html;
       try_files $uri /index.html;
 
-      # cache everything for 1 week
-      add_header 'Cache-Control' 'max-age: 604800, immutable' always; 
+      # cache everything for 1 year
+      add_header 'Cache-Control' 'max-age: 31536000, immutable' always; 
   }
 
   # do not cache index.html - https://phabricator.wikimedia.org/T331423


### PR DESCRIPTION
https://phabricator.wikimedia.org/T331423

Adds the `Cache-Control` header to the nginx response. Forces revalidation for `index.html`
