### PR TITLE
chore: lock entity ids to pre-mul revisions

### DIFF
--- a/src/backend/api.js
+++ b/src/backend/api.js
@@ -90,7 +90,20 @@ export const wikiDiscovery = async ({ sort, direction, active, currentPage, resu
 
 export const importEntities = async ({
   wikiId,
-  entityIds = ['P22', 'P25', 'P40', 'P18', 'P31', 'P279', 'Q1', 'Q2', 'Q5', 'Q64', 'Q42', 'Q3107329'],
+  entityIds = [
+    'P22@2199351820',
+    'P25@2142619520',
+    'P40@2211223166',
+    'P18@2207212164',
+    'P31@2214227295',
+    'P279@2217210867',
+    'Q1@2216755517',
+    'Q2@2216196627',
+    'Q5@2212749099',
+    'Q64@2215506799',
+    'Q42@2213635313',
+    'Q3107329@2211072210'
+  ],
   sourceWikiUrl = 'https://www.wikidata.org'
 }) => {
   const { data: { data } } = await axios.post('/wiki/entityImport', {


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T360031

We found the recent introduction of the `mul` language code in wikidata led to mass deletion of redundant labels on certain entities already. These entities would now have sparsely populated labels when imported into cloud, which is lacking `mul` support.

The revisions were picked as "either latest of today in case no `mul` data is present, or the last revision without `mul` data". (Only Q42 has mul data as of now).