### PR TITLE
workflow: update node version matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 15]
+        node-version: [15, 16, 18, 20]
 
     steps:
     - uses: actions/checkout@v3.5.3


### PR DESCRIPTION
It only now makes sense to test the current and future versions of node we might wish to upgrade to