### PR TITLE
add script `lint-fix`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e --baseUrl=http://ui:8081/",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "fix": "vue-cli-service lint --fix"
   },
   "dependencies": {
     "axios": "^1.7.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e --baseUrl=http://ui:8081/",
     "lint": "vue-cli-service lint",
-    "fix": "vue-cli-service lint --fix"
+    "lint-fix": "vue-cli-service lint --fix"
   },
   "dependencies": {
     "axios": "^1.7.5",


### PR DESCRIPTION
- we use linting checks in CI
- this adds a "script" entry in package.json so you can run `npm run lint-fix` to fix formatting

