### PR TITLE
Fix contact page heading alignment (Bug: T401820)

### DIFF
--- a/src/components/Pages/Complaint.vue
+++ b/src/components/Pages/Complaint.vue
@@ -2,6 +2,13 @@
   <v-main>
     <v-responsive max-width="616px" min-width="250px" >
       <div class="body">
+        <p class="text-body-1 font-weight-bold mb-2">
+          Points of contact under the Digital Services Act (Regulation 2022/2065/EU)
+        </p>
+        <p class="text-subtitle-2 font-weight-regular mb-8">
+          Point of contact for public authorities under Art. 11 DSA: dsa-meldung@wikimedia.de<br/>
+          Point of contact for recipients under Art. 12 DSA: dsa-meldung@wikimedia.de
+        </p>
         <h1 class="text-h4 mb-4">Reporting illegal content</h1>
         <p class="text-body-1 mb-9">
           Please use this form to report any content that you consider to be illegal. After sending the email,

--- a/src/components/Pages/Contact.vue
+++ b/src/components/Pages/Contact.vue
@@ -1,7 +1,8 @@
 <template>
     <v-main>
           <v-responsive max-width="840px" min-width="250px" >
-              <h1>Get in touch with the team</h1>
+              <h4 class="page-heading">Get in touch with the team</h4>
+
               <p>Thank you for your interest. We want to hear what you've got to say.</p>
               <p>Have you got a question? First, check our <a href="https://www.mediawiki.org/wiki/Wikibase/Wikibase.cloud/FAQ" target="_blank">FAQ</a> to see if we've already answered it. We're constantly  updating it with new questions. If you don't find an answer there, feel free to use the contact form below. Thanks!</p>
               <p>Please note that despite our best efforts it can take up to two weeks to receive a response. Thank you for your patience.</p>


### PR DESCRIPTION
### Summary
This PR fixes the incorrect heading alignment on the Contact page.

### Changes made
- Corrected the heading style to match design guidelines.
- Ensured proper spacing and consistent font size.

### Bug reference
Bug: T401820 (https://phabricator.wikimedia.org/T401820)

Please review. Thanks!
