### PR TITLE
Introduce linting to restrict line length to 120 chars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,8 @@ module.exports = {
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'vue/multi-word-component-names': 'warn',
     'vue/no-reserved-component-names': 'warn',
-    'vue/no-mutating-props': 'warn'
+    'vue/no-mutating-props': 'warn',
+    'max-len': ['error', {'code': 120}]
   },
   overrides: [
     {


### PR DESCRIPTION
This adds an eslint rule to restrict line length to 120 chars.

This does not fix lines longer than this. These fixes will need to be applied before merging