### PR TITLE
fix scroll behaviour

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -142,6 +142,18 @@ const router = new Router({
       },
     },
   ],
+  scrollBehavior (to, from, savedPosition) {
+    // brings viewport back to where it was when using Back button
+    if (savedPosition) return savedPosition
+
+    // scroll to in-page router-link anchor if used
+    if (to.hash) {
+      return { selector: to.hash, behavior: 'smooth' }
+    }
+
+    // default: scroll to the top of the page
+    return { x: 0, y: 0, behavior: 'smooth' }
+  },
 })
 
 // Require some routes to be logged in only.


### PR DESCRIPTION
This change came up with https://github.com/wbstack/ui/pull/1128 and I put it in its own PR because https://github.com/wbstack/ui/pull/1130 also needs this

This fix addresses several things:
1. scroll to the top of the page after following an internal page link
2. making on-page anchor-links (#) work specified with vue router-link

https://phabricator.wikimedia.org/T408254
https://phabricator.wikimedia.org/T420575

