### PR TITLE
dev: separate out metal and docker local dev env files

### DIFF
--- a/.env.development.local.baremetal
+++ b/.env.development.local.baremetal
@@ -1,6 +1,6 @@
-# For local development using a Platform API that can be accessed via the host machine's localhost
+# For local development on bare metal using a Platform API that can be accessed via localhost
 NODE_ENV=development
-VUE_APP_API_URL=http://host.docker.internal:8082
+VUE_APP_API_URL=http://localhost:8082
 VUE_APP_API_MOCK=0
 VUE_APP_RECAPTCHA_SITE_KEY="6LeHzbMUAAAAABjNp0vILaWr5ZeYHmteF7rGuZNV"
 VUE_APP_BUILD_FOR_DOCKER_IMAGE=0

--- a/.env.development.local.docker
+++ b/.env.development.local.docker
@@ -1,0 +1,8 @@
+# For local development in docker using a Platform API that can be accessed via the host machine's localhost
+NODE_ENV=development
+VUE_APP_API_URL=http://host.docker.internal:8082
+VUE_APP_API_MOCK=0
+VUE_APP_RECAPTCHA_SITE_KEY="6LeHzbMUAAAAABjNp0vILaWr5ZeYHmteF7rGuZNV"
+VUE_APP_BUILD_FOR_DOCKER_IMAGE=0
+VUE_APP_CNAME_RECORD=sites-1.dyna.wbaas.dev
+VUE_APP_SUBDOMAIN_SUFFIX=".wbaas.dev"


### PR DESCRIPTION
We discovered that the APP_API_URL needs to differ in the baremetal vs docker use case so this adds separate env file for the baremetal usecase and rename the existing one to clarify it's for docker