### PR TITLE
testing: use production environment for e2e tests

### DIFF
--- a/.env.development.test
+++ b/.env.development.test
@@ -1,5 +1,5 @@
 # For running GitHub Actions tests using docker
-NODE_ENV=development
+NODE_ENV=production
 VUE_APP_API_URL=http://host.docker.internal:8082
 VUE_APP_API_MOCK=0
 VUE_APP_RECAPTCHA_SITE_KEY="6LeHzbMUAAAAABjNp0vILaWr5ZeYHmteF7rGuZNV" # todo replace with test key

--- a/.github/workflows/browser-tests.js.yml
+++ b/.github/workflows/browser-tests.js.yml
@@ -39,7 +39,7 @@ jobs:
       - run: sudo chown -R 1000:1000 .
         working-directory: ui
 
-      - run: docker compose run --rm ui npm ci
+      - run: docker compose run --rm --env NODE_ENV=development ui npm ci
         working-directory: ui
 
       - run: docker compose run --rm ui npm run build

--- a/.github/workflows/browser-tests.js.yml
+++ b/.github/workflows/browser-tests.js.yml
@@ -42,7 +42,7 @@ jobs:
       - run: docker compose run --rm ui npm install
         working-directory: ui
 
-      - run: docker compose --profile browser-tests up --wait
+      - run: docker compose --profile browser-tests up
         working-directory: ui
 
       - run: docker compose exec -it ui npm run test:e2e

--- a/.github/workflows/browser-tests.js.yml
+++ b/.github/workflows/browser-tests.js.yml
@@ -42,9 +42,6 @@ jobs:
       - run: docker compose run --rm --env NODE_ENV=development ui npm ci
         working-directory: ui
 
-      - run: docker compose run --rm ui npm run build
-        working-directory: ui
-
       - run: docker compose --profile browser-tests up --wait
         working-directory: ui
 

--- a/.github/workflows/browser-tests.js.yml
+++ b/.github/workflows/browser-tests.js.yml
@@ -42,6 +42,9 @@ jobs:
       - run: docker compose run --rm ui npm install
         working-directory: ui
 
+      - run: docker compose run --rm ui npm run build
+        working-directory: ui
+
       - run: docker compose --profile browser-tests up --wait
         working-directory: ui
 

--- a/.github/workflows/browser-tests.js.yml
+++ b/.github/workflows/browser-tests.js.yml
@@ -39,7 +39,7 @@ jobs:
       - run: sudo chown -R 1000:1000 .
         working-directory: ui
 
-      - run: docker compose run --rm ui npm install
+      - run: docker compose run --rm ui npm ci
         working-directory: ui
 
       - run: docker compose run --rm ui npm run build

--- a/.github/workflows/browser-tests.js.yml
+++ b/.github/workflows/browser-tests.js.yml
@@ -42,7 +42,7 @@ jobs:
       - run: docker compose run --rm ui npm install
         working-directory: ui
 
-      - run: docker compose --profile browser-tests up -d --wait
+      - run: docker compose --profile browser-tests up --wait
         working-directory: ui
 
       - run: docker compose exec -it ui npm run test:e2e

--- a/.github/workflows/browser-tests.js.yml
+++ b/.github/workflows/browser-tests.js.yml
@@ -36,13 +36,10 @@ jobs:
       - run: cp .env.development.test .env
         working-directory: ui
 
-      - run: sudo chown -R 1000:1000 .
-        working-directory: ui
-
       - run: docker compose run --rm ui npm install
         working-directory: ui
 
-      - run: docker compose --profile browser-tests up
+      - run: docker compose --profile browser-tests up --wait
         working-directory: ui
 
       - run: docker compose exec -it ui npm run test:e2e

--- a/.github/workflows/browser-tests.js.yml
+++ b/.github/workflows/browser-tests.js.yml
@@ -36,6 +36,9 @@ jobs:
       - run: cp .env.development.test .env
         working-directory: ui
 
+      - run: sudo chown -R 1000:1000 .
+        working-directory: ui
+
       - run: docker compose run --rm ui npm install
         working-directory: ui
 


### PR DESCRIPTION
When using the development environment if a request fails the screen is blocked by a helpful debugging message.

I believe the `login` request that happens in the background regularly fails since we updated passport in the platform api. This then blocks clicking any other elements.

The e2e tests rely on the main branch of api to test against which explains why we transition into status tests failing without merging a PR that had failing status tests.

This commit uses the production environment for running the end to end tests. It also adjusts the npm install step. It retains the development environment for installation and uses npm ci[1] rather than install to make this test more deterministic and use the exact versions of packages specified in the lock file.

Finally this commit also uses a plain docker compose --wait and removes the -d since wait already implies detached mode. [2]

[1] https://docs.npmjs.com/cli/v11/commands/npm-ci
[2] https://docs.docker.com/reference/cli/docker/compose/up/

Bug: T428389