### PR TITLE
Handle special case of Pilot for Hosting Policy

### DIFF
--- a/src/components/Layout/Foot.vue
+++ b/src/components/Layout/Foot.vue
@@ -21,7 +21,7 @@
           <ul class="footer-list">
             <li><router-link to="/privacy-policy">Privacy Policy</router-link></li>
             <li><router-link to="/terms-of-use">Terms of Use</router-link></li>
-            <li><router-link to="/hosting-policy/pilot">Hosting Policy</router-link></li>
+            <li><router-link to="/hosting-policy">Hosting Policy</router-link></li>
             <li><router-link to="/dsa-info">Digital Services Act Information</router-link></li>
             <li><a target="_blank" rel="noopener noreferrer" href="https://www.wikimedia.de/impressum/">Imprint</a></li>
             <li><router-link to="/complaint">Report illegal content</router-link></li>

--- a/src/components/Pages/HostingPolicy/HostingPolicyRenderer.vue
+++ b/src/components/Pages/HostingPolicy/HostingPolicyRenderer.vue
@@ -69,6 +69,11 @@ export default {
           response = await this.$api.getUpcomingPolicyByType({ policyType })
         } else if (this.isCurrentRoute) {
           response = await this.$api.getCurrentPolicyByType({ policyType })
+          if (response === undefined) {
+            // Special case to redirect users to the pilot policy if there is no current policy
+            // Remove afer T408316
+            this.$router.replace({ path: '/hosting-policy/pilot' })
+          }
         } else {
           response = await this.$api.getPolicyByDate({ policyType, activeFrom })
         }

--- a/src/components/Pages/HostingPolicyPilot.vue
+++ b/src/components/Pages/HostingPolicyPilot.vue
@@ -279,6 +279,7 @@
 </template>
 
 <script>
+// Legacy file. Remove after T408316
 export default {
   name: 'HostingPolicy',
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,7 +19,7 @@ import Privacy from '@/components/Pages/Privacy/Privacy'
 import User from '@/components/Pages/User'
 import Discovery from '@/components/Pages/Discovery/Discovery'
 import Complaint from '@/components/Pages/Complaint.vue'
-import HostingPolicy from '@/components/Pages/HostingPolicy.vue'
+import HostingPolicyPilot from '@/components/Pages/HostingPolicyPilot.vue'
 import HostingPolicyRenderer from '@/components/Pages/HostingPolicy/HostingPolicyRenderer.vue'
 import DsaInfo from '@/components/Pages/DsaInfo/DsaInfo'
 
@@ -92,9 +92,9 @@ const router = new Router({
       component: HostingPolicyRenderer,
     },
     {
-      path: '/hosting-policy/pilot',
+      path: '/hosting-policy/pilot', // Remove after T408316
       name: 'HostingPolicyPilot',
-      component: HostingPolicy,
+      component: HostingPolicyPilot,
     },
     {
       path: '/hosting-policy/:activeFrom',


### PR DESCRIPTION
A rather unelegant workaround to handle the case of no currrent hosting policy to redirect people to the pilot.

This allows us to change the footer link to be just '/hosting-policy' and have it handled by the HostingPolicyRenderer but still redirect to the pilot component.

Added comments to ensure we remove this cruft as soon as the pilot policy is redundant.

Bug: T432965